### PR TITLE
Comente las lineas que evitaban levantar el back

### DIFF
--- a/api/src/db.js
+++ b/api/src/db.js
@@ -50,11 +50,11 @@ Product.belongsTo(Category);
 Promotion.hasMany(Product);
 Product.belongsTo(Promotion);
 
-Product.belongsToMany(Favorite, {through: 'product_favorite'});
-Favorite.belongsToMany(Product, {through: 'product_favorite'});
+// Product.belongsToMany(Favorite, {through: 'product_favorite'});
+// Favorite.belongsToMany(Product, {through: 'product_favorite'});
 
-Favorite.belongsTo(User);
-User.belongsTo(Favorite);
+// Favorite.belongsTo(User);
+// User.belongsTo(Favorite);
 
 
 module.exports = {


### PR DESCRIPTION
Las relaciones en Los modelos Favoritos están mal

La tabla favoritos ya es una tabla intermedia, no es necesario crearla
Recuerden que la Asociacion User-Products interactúa de la misma manera en el shopping cart `({ through: 'user_products'})` que en Favoritos, no fue necesario crear un modelo para shopping cart, se crea automáticamente al hacer la asociación Many-to-Many

Revisar que no tengan componentes que rompan la app antes de hacer pull request